### PR TITLE
Fix schema generation for embedded struct field tags

### DIFF
--- a/schema/create.go
+++ b/schema/create.go
@@ -73,7 +73,14 @@ func collectStructFields(t reflect.Type, schema *JSON) {
 			continue
 		}
 
-		// Handle embedded/anonymous structs - promote their fields to the parent
+		// In Go, an anonymous (embedded) struct field promotes its fields to the
+		// parent struct. encoding/json flattens these into the parent JSON object
+		// rather than nesting them. We mirror that behavior here: when we encounter
+		// an anonymous field whose underlying type is a struct, we recurse into it
+		// and collect its fields directly into the parent schema. This ensures that
+		// struct tags (json-enum, json-description, etc.) on the embedded struct's
+		// fields are preserved in the parent schema. Pointer-to-struct embeddings
+		// (e.g. *Embedded) are handled by dereferencing the pointer type first.
 		if field.Anonymous {
 			ft := field.Type
 			if ft.Kind() == reflect.Ptr {

--- a/schema/create.go
+++ b/schema/create.go
@@ -37,34 +37,7 @@ func typeToSchema(t reflect.Type) *JSON {
 		schema.Properties = make(map[string]*JSON)
 		schema.Required = []string{}
 
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-
-			// Skip unexported fields
-			if !field.IsExported() {
-				continue
-			}
-
-			// Get the JSON field name from the json tag
-			jsonTag := field.Tag.Get("json")
-			name := strings.Split(jsonTag, ",")[0]
-			if name == "-" {
-				continue
-			}
-			if name == "" {
-				name = field.Name
-			}
-
-			// Check if this field is required
-			if !strings.Contains(jsonTag, "omitempty") {
-				schema.Required = append(schema.Required, name)
-			}
-
-			fieldSchema := fieldToSchema(field)
-			if fieldSchema != nil {
-				schema.Properties[name] = fieldSchema
-			}
-		}
+		collectStructFields(t, schema)
 
 		if len(schema.Required) == 0 {
 			schema.Required = nil
@@ -89,6 +62,49 @@ func typeToSchema(t reflect.Type) *JSON {
 	}
 
 	return schema
+}
+
+func collectStructFields(t reflect.Type, schema *JSON) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Handle embedded/anonymous structs - promote their fields to the parent
+		if field.Anonymous {
+			ft := field.Type
+			if ft.Kind() == reflect.Ptr {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct {
+				collectStructFields(ft, schema)
+				continue
+			}
+		}
+
+		// Get the JSON field name from the json tag
+		jsonTag := field.Tag.Get("json")
+		name := strings.Split(jsonTag, ",")[0]
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+
+		// Check if this field is required
+		if !strings.Contains(jsonTag, "omitempty") {
+			schema.Required = append(schema.Required, name)
+		}
+
+		fieldSchema := fieldToSchema(field)
+		if fieldSchema != nil {
+			schema.Properties[name] = fieldSchema
+		}
+	}
 }
 
 func fieldToSchema(field reflect.StructField) *JSON {

--- a/schema/create_test.go
+++ b/schema/create_test.go
@@ -547,6 +547,181 @@ func TestFrom_EmbeddedPointerStruct(t *testing.T) {
 	}
 }
 
+func TestFrom_EmbeddedStructWithDescription(t *testing.T) {
+	type Metadata struct {
+		Source string `json:"source" json-description:"Origin of the record" json-enum:"manual,import,api"`
+	}
+	type Record struct {
+		Metadata
+		Data string `json:"data"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"source": {
+				Type:        schema.String,
+				Description: "Origin of the record",
+				Enum:        []interface{}{"manual", "import", "api"},
+			},
+			"data": {Type: schema.String},
+		},
+		Required: []string{"source", "data"},
+	}
+
+	result := schema.From(Record{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedStructWithOmitempty(t *testing.T) {
+	type Optional struct {
+		Note string `json:"note,omitempty"`
+	}
+	type Parent struct {
+		Optional
+		Name string `json:"name"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"note": {Type: schema.String},
+			"name": {Type: schema.String},
+		},
+		Required: []string{"name"},
+	}
+
+	result := schema.From(Parent{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedStructMultipleEmbeds(t *testing.T) {
+	type Timestamps struct {
+		CreatedAt string `json:"created_at"`
+		UpdatedAt string `json:"updated_at,omitempty"`
+	}
+	type Identifiers struct {
+		ID   int    `json:"id" json-minimum:"1"`
+		Code string `json:"code" json-enum:"X,Y,Z"`
+	}
+	type Entity struct {
+		Timestamps
+		Identifiers
+		Name string `json:"name"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"created_at": {Type: schema.String},
+			"updated_at": {Type: schema.String},
+			"id":         {Type: schema.Integer, Minimum: ptr(1.)},
+			"code":       {Type: schema.String, Enum: []interface{}{"X", "Y", "Z"}},
+			"name":       {Type: schema.String},
+		},
+		Required: []string{"created_at", "id", "code", "name"},
+	}
+
+	result := schema.From(Entity{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedStructWithNestedStruct(t *testing.T) {
+	// Verify that embedded structs are promoted while regular named struct fields stay nested
+	type Shared struct {
+		Tag string `json:"tag" json-enum:"a,b"`
+	}
+	type Inner struct {
+		X int `json:"x"`
+	}
+	type Combined struct {
+		Shared
+		Inner Inner `json:"inner"`
+		Y     int   `json:"y"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"tag": {Type: schema.String, Enum: []interface{}{"a", "b"}},
+			"inner": {
+				Type: schema.Object,
+				Properties: map[string]*schema.JSON{
+					"x": {Type: schema.Integer},
+				},
+				Required: []string{"x"},
+			},
+			"y": {Type: schema.Integer},
+		},
+		Required: []string{"tag", "inner", "y"},
+	}
+
+	result := schema.From(Combined{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedStructWithNumberValidation(t *testing.T) {
+	type Limits struct {
+		Score   float64 `json:"score" json-minimum:"0.0" json-maximum:"100.0"`
+		Count   int     `json:"count" json-exclusive-minimum:"0" json-exclusive-maximum:"1000"`
+	}
+	type Report struct {
+		Limits
+		Title string `json:"title"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"score": {Type: schema.Number, Minimum: ptr(0.0), Maximum: ptr(100.0)},
+			"count": {Type: schema.Integer, ExclusiveMinimum: ptr(0.0), ExclusiveMaximum: ptr(1000.0)},
+			"title": {Type: schema.String},
+		},
+		Required: []string{"score", "count", "title"},
+	}
+
+	result := schema.From(Report{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedStructWithStringValidation(t *testing.T) {
+	type Constraints struct {
+		Email string `json:"email" json-format:"email" json-min-length:"5" json-max-length:"254"`
+		Slug  string `json:"slug" json-pattern:"^[a-z0-9-]+$"`
+	}
+	type Profile struct {
+		Constraints
+		DisplayName string `json:"display_name"`
+	}
+
+	format := "email"
+	pattern := "^[a-z0-9-]+$"
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"email":        {Type: schema.String, Format: &format, MinLength: ptr(5), MaxLength: ptr(254)},
+			"slug":         {Type: schema.String, Pattern: &pattern},
+			"display_name": {Type: schema.String},
+		},
+		Required: []string{"email", "slug", "display_name"},
+	}
+
+	result := schema.From(Profile{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }

--- a/schema/create_test.go
+++ b/schema/create_test.go
@@ -467,6 +467,86 @@ func TestFrom_InvalidTags(t *testing.T) {
 	}
 }
 
+func TestFrom_EmbeddedStruct(t *testing.T) {
+	type Category struct {
+		Kind string `json:"kind" json-enum:"alpha,beta,gamma"`
+	}
+	type Item struct {
+		Category
+		Label string `json:"label"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"kind": {
+				Type: schema.String,
+				Enum: []interface{}{"alpha", "beta", "gamma"},
+			},
+			"label": {Type: schema.String},
+		},
+		Required: []string{"kind", "label"},
+	}
+
+	result := schema.From(Item{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedStructMultiLevel(t *testing.T) {
+	type Base struct {
+		ID int `json:"id" json-minimum:"1"`
+	}
+	type Middle struct {
+		Base
+		Name string `json:"name" json-max-length:"100"`
+	}
+	type Top struct {
+		Middle
+		Extra string `json:"extra"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"id":    {Type: schema.Integer, Minimum: ptr(1.)},
+			"name":  {Type: schema.String, MaxLength: ptr(100)},
+			"extra": {Type: schema.String},
+		},
+		Required: []string{"id", "name", "extra"},
+	}
+
+	result := schema.From(Top{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestFrom_EmbeddedPointerStruct(t *testing.T) {
+	type Embedded struct {
+		Value string `json:"value" json-enum:"A,B,C"`
+	}
+	type Outer struct {
+		*Embedded
+		Other int `json:"other"`
+	}
+
+	expected := &schema.JSON{
+		Type: schema.Object,
+		Properties: map[string]*schema.JSON{
+			"value": {Type: schema.String, Enum: []interface{}{"A", "B", "C"}},
+			"other": {Type: schema.Integer},
+		},
+		Required: []string{"value", "other"},
+	}
+
+	result := schema.From(Outer{})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }


### PR DESCRIPTION
https://gitlab.modfin.sh/modfin/tickets/-/issues/19183

## Summary
- Embedded (anonymous) struct fields now have their fields promoted to the parent schema, matching `encoding/json` behavior
- Struct tags like `json-enum`, `json-description`, `json-minimum`, etc. are preserved on fields from embedded structs
- Supports pointer embeddings and multi-level embedding

## Test plan
- [x] Added `TestFrom_EmbeddedStruct` — basic embedded struct with `json-enum`
- [x] Added `TestFrom_EmbeddedStructMultiLevel` — three levels of embedding
- [x] Added `TestFrom_EmbeddedPointerStruct` — pointer-based embedding
- [x] All existing tests pass