### PR TITLE
Context retention fixes: agent history, Gemini signatures, prompt caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,42 @@ answer, err := res.AsText()
 fmt.Println(answer, err)
 ```
 
+## Prompt Caching
+
+Every turn of a conversation resends the whole history, so the same system prompt,
+tool definitions and prior turns get processed again and again. `PromptCache(true)`
+asks the provider to cache that reusable prefix.
+
+```go
+llm := anthropic.New(apiKey).Generator().
+    Model(anthropic.GenModel_4_5_sonnet_latest).
+    System(longRuleBook). // the expensive, unchanging part of every request
+    SetTools(getQuote, getStock).
+    PromptCache(true)
+
+res, err := llm.Prompt(prompt.AsUser("Get me the price of Volvo B"))
+if err != nil {
+    log.Fatalf("Prompt() error = %v", err)
+}
+
+fmt.Println(res.Metadata.CachedTokens, res.Metadata.CacheWriteTokens)
+// 6312 0
+```
+
+Providers differ in what the flag does. Anthropic needs explicit cache breakpoints,
+and bellman places them (on the tool definitions, the system prompt and the end of
+the conversation) only when this is enabled. OpenAI and VertexAI cache eligible
+prefixes automatically, so the flag changes nothing for them.
+
+Either way the accounting is reported the same way, as a subset of the input tokens:
+
+- `Metadata.CachedTokens` - input served from cache, billed at a discount
+- `Metadata.CacheWriteTokens` - input written to the cache, billed at a premium
+
+Caching only kicks in above a model dependent minimum prefix length (roughly 1-2k
+tokens) and entries are evicted after a few minutes of inactivity. Below that, the
+request behaves as if caching were off.
+
 ## Provider specific config
 Some providers have specific configuration that is not supported by the common interface.
 You can set these options manually on the `gen.Model.Config` struct.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -22,6 +22,11 @@ func Run[T any](maxDepth int, parallelism int, g *gen.Generator, prompts ...prom
 		g = g.Output(schema.From(result))
 	}
 
+	// Own the history. prompts... aliases the caller's backing array, and the
+	// loop below appends to it - without a copy those appends write into the
+	// caller's spare capacity.
+	prompts = append([]prompt.Prompt{}, prompts...)
+
 	promptMetadata := models.Metadata{Model: g.Request.Model.Name}
 	for i := 0; i < maxDepth; i++ {
 		resp, err := g.Prompt(prompts...)
@@ -32,8 +37,15 @@ func Run[T any](maxDepth int, parallelism int, g *gen.Generator, prompts ...prom
 		promptMetadata.ThinkingTokens += resp.Metadata.ThinkingTokens
 		promptMetadata.OutputTokens += resp.Metadata.OutputTokens
 		promptMetadata.TotalTokens += resp.Metadata.TotalTokens
+		promptMetadata.CachedTokens += resp.Metadata.CachedTokens
+		promptMetadata.CacheWriteTokens += resp.Metadata.CacheWriteTokens
 
 		if !resp.IsTools() {
+			// Replay-ready record of the turn that produced the result, so
+			// Result.Prompts is a complete conversation the caller can extend
+			// with a new user prompt.
+			prompts = append(prompts, resp.Turn...)
+
 			// Check if T is string type and handle directly
 			if resultIsString {
 				text, err := resp.AsText()
@@ -125,6 +137,9 @@ func RunWithToolsOnly[T any](maxDepth int, parallelism int, g *gen.Generator, pr
 	})
 	g = g.SetToolConfig(tools.RequiredTool)
 
+	// Own the history, see Run.
+	prompts = append([]prompt.Prompt{}, prompts...)
+
 	promptMetadata := models.Metadata{Model: g.Request.Model.Name}
 	for i := 0; i < maxDepth; i++ {
 		resp, err := g.Prompt(prompts...)
@@ -135,6 +150,8 @@ func RunWithToolsOnly[T any](maxDepth int, parallelism int, g *gen.Generator, pr
 		promptMetadata.ThinkingTokens += resp.Metadata.ThinkingTokens
 		promptMetadata.OutputTokens += resp.Metadata.OutputTokens
 		promptMetadata.TotalTokens += resp.Metadata.TotalTokens
+		promptMetadata.CachedTokens += resp.Metadata.CachedTokens
+		promptMetadata.CacheWriteTokens += resp.Metadata.CacheWriteTokens
 
 		callbacks, err := resp.AsTools()
 		if err != nil {
@@ -148,6 +165,16 @@ func RunWithToolsOnly[T any](maxDepth int, parallelism int, g *gen.Generator, pr
 				err = json.Unmarshal(callback.Argument, &finalResult)
 				if err != nil {
 					return nil, fmt.Errorf("could not unmarshal final result: %w, at depth %d", err, i)
+				}
+				// Only the assistant text of the final turn is replay-safe. The
+				// synthetic result tool call never gets a tool response, and any
+				// provider signature on the turn is validated against the tool
+				// call that we drop - so neither is part of the returned
+				// conversation.
+				for _, p := range resp.Turn {
+					if p.Role == prompt.AssistantRole && p.Text != "" {
+						prompts = append(prompts, p)
+					}
 				}
 				return &Result[T]{
 					Prompts:  prompts,
@@ -192,6 +219,10 @@ func RunWithToolsOnly[T any](maxDepth int, parallelism int, g *gen.Generator, pr
 }
 
 type Result[T any] struct {
+	// Prompts is the full conversation of the run in replay-ready form: the
+	// prompts it was called with, every assistant turn (including thinking and
+	// tool calls with their provider signatures) and every tool response.
+	// Append a new user prompt to it to continue the conversation.
 	Prompts  []prompt.Prompt
 	Result   T
 	Metadata models.Metadata

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,195 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modfin/bellman/agent"
+	"github.com/modfin/bellman/models/gen"
+	"github.com/modfin/bellman/prompt"
+	"github.com/modfin/bellman/tools"
+)
+
+// stubPrompter plays back a canned sequence of responses and records the
+// conversation it was handed on every call, so the agent loop's history
+// bookkeeping can be asserted without a provider.
+type stubPrompter struct {
+	responses []*gen.Response
+	calls     int
+	seen      [][]prompt.Prompt
+}
+
+func (s *stubPrompter) SetRequest(gen.Request) {}
+
+func (s *stubPrompter) Prompt(prompts ...prompt.Prompt) (*gen.Response, error) {
+	s.seen = append(s.seen, append([]prompt.Prompt(nil), prompts...))
+	if s.calls >= len(s.responses) {
+		return nil, errors.New("stub: no responses left")
+	}
+	r := s.responses[s.calls]
+	s.calls++
+	return r, nil
+}
+
+func (s *stubPrompter) Stream(...prompt.Prompt) (<-chan *gen.StreamResponse, error) {
+	return nil, errors.New("stub: streaming not supported")
+}
+
+type priceResult struct {
+	Price float64 `json:"price"`
+}
+
+func priceTool(t *testing.T) tools.Tool {
+	t.Helper()
+	return tools.NewTool("get_price",
+		tools.WithDescription("get a price"),
+		tools.WithArgSchema(tools.EmptyArgs{}),
+		tools.WithFunction(func(ctx context.Context, call tools.Call) (string, error) {
+			return `{"price":42.5}`, nil
+		}),
+	)
+}
+
+func stubGenerator(p gen.Prompter, tool tools.Tool) *gen.Generator {
+	g := &gen.Generator{
+		Prompter: p,
+		Request:  gen.Request{Model: gen.Model{Provider: "stub", Name: "stub"}},
+	}
+	return g.SetTools(tool)
+}
+
+// The terminating assistant turn must end up in Result.Prompts, otherwise the
+// returned conversation cannot be used as the history for a follow-up turn —
+// the model's own answer, and the signature attached to it, would be missing.
+func TestRunResultPromptsIncludeFinalAssistantTurn(t *testing.T) {
+	tool := priceTool(t)
+	stub := &stubPrompter{responses: []*gen.Response{
+		{
+			Tools: []tools.Call{{ID: "call-1", Name: "get_price", Argument: []byte(`{}`), Ref: &tool}},
+			Turn: []prompt.Prompt{
+				prompt.AsThinking("i should look up the price", []byte("sig-1"), "r1"),
+				prompt.AsToolCall("call-1", "get_price", []byte(`{}`)),
+			},
+		},
+		{
+			Texts: []string{`{"price":42.5}`},
+			Turn: []prompt.Prompt{
+				prompt.AsThinking("the tool gave me the price", []byte("sig-2"), "r2"),
+				prompt.AsAssistant(`{"price":42.5}`),
+			},
+		},
+	}}
+
+	res, err := agent.Run[priceResult](5, 1, stubGenerator(stub, tool), prompt.AsUser("what is the price?"))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if res.Result.Price != 42.5 {
+		t.Fatalf("Result.Price = %v, want 42.5", res.Result.Price)
+	}
+
+	wantRoles := []prompt.Role{
+		prompt.UserRole,
+		prompt.ThinkingRole,
+		prompt.ToolCallRole,
+		prompt.ToolResponseRole,
+		prompt.ThinkingRole,
+		prompt.AssistantRole,
+	}
+	if len(res.Prompts) != len(wantRoles) {
+		t.Fatalf("len(Result.Prompts) = %d, want %d: %+v", len(res.Prompts), len(wantRoles), res.Prompts)
+	}
+	for i, want := range wantRoles {
+		if res.Prompts[i].Role != want {
+			t.Errorf("Result.Prompts[%d].Role = %q, want %q", i, res.Prompts[i].Role, want)
+		}
+	}
+
+	last := res.Prompts[len(res.Prompts)-1]
+	if last.Text != `{"price":42.5}` {
+		t.Errorf("final prompt text = %q, want the assistant answer", last.Text)
+	}
+	if got := string(res.Prompts[4].Replay); got != "sig-2" {
+		t.Errorf("final thinking Replay = %q, want %q", got, "sig-2")
+	}
+}
+
+// Run must not write into the caller's slice. Passing prompts... aliases the
+// caller's backing array, so appending the assistant turn can clobber elements
+// past len that the caller (or another slice of the same array) still owns.
+func TestRunDoesNotMutateCallerPrompts(t *testing.T) {
+	tool := priceTool(t)
+	stub := &stubPrompter{responses: []*gen.Response{
+		{
+			Tools: []tools.Call{{ID: "call-1", Name: "get_price", Argument: []byte(`{}`), Ref: &tool}},
+			Turn:  []prompt.Prompt{prompt.AsToolCall("call-1", "get_price", []byte(`{}`))},
+		},
+		{
+			Texts: []string{`{"price":42.5}`},
+			Turn:  []prompt.Prompt{prompt.AsAssistant(`{"price":42.5}`)},
+		},
+	}}
+
+	sentinel := prompt.AsUser("SENTINEL")
+	backing := make([]prompt.Prompt, 4)
+	backing[0] = prompt.AsUser("what is the price?")
+	for i := 1; i < len(backing); i++ {
+		backing[i] = sentinel
+	}
+	caller := backing[:1]
+
+	_, err := agent.Run[priceResult](5, 1, stubGenerator(stub, tool), caller...)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	for i := 1; i < len(backing); i++ {
+		if backing[i].Text != sentinel.Text {
+			t.Fatalf("Run wrote into the caller's backing array at index %d: %+v", i, backing[i])
+		}
+	}
+	if len(caller) != 1 {
+		t.Fatalf("caller slice length changed to %d", len(caller))
+	}
+}
+
+// RunWithToolsOnly extracts its result from a synthetic tool call that never
+// gets a tool response, so that call must not be replayed as history — but the
+// assistant text of the final turn is safe to keep.
+func TestRunWithToolsOnlyPromptsAreReplaySafe(t *testing.T) {
+	tool := priceTool(t)
+	resultCall := tools.Call{ID: "call-2", Name: "__return_result_tool__", Argument: []byte(`{"price":42.5}`)}
+	stub := &stubPrompter{responses: []*gen.Response{
+		{
+			Tools: []tools.Call{{ID: "call-1", Name: "get_price", Argument: []byte(`{}`), Ref: &tool}},
+			Turn:  []prompt.Prompt{prompt.AsToolCall("call-1", "get_price", []byte(`{}`))},
+		},
+		{
+			Tools: []tools.Call{resultCall},
+			Turn: []prompt.Prompt{
+				prompt.AsThinking("wrapping up", []byte("sig-2"), "r2"),
+				prompt.AsAssistant("here is the price"),
+				prompt.AsToolCall(resultCall.ID, resultCall.Name, resultCall.Argument),
+			},
+		},
+	}}
+
+	res, err := agent.RunWithToolsOnly[priceResult](5, 1, stubGenerator(stub, tool), prompt.AsUser("what is the price?"))
+	if err != nil {
+		t.Fatalf("RunWithToolsOnly() error = %v", err)
+	}
+	if res.Result.Price != 42.5 {
+		t.Fatalf("Result.Price = %v, want 42.5", res.Result.Price)
+	}
+
+	for i, p := range res.Prompts {
+		if p.Role == prompt.ToolCallRole && p.ToolCall != nil && p.ToolCall.Name == "__return_result_tool__" {
+			t.Fatalf("Result.Prompts[%d] replays the synthetic result tool call, which has no tool response", i)
+		}
+	}
+	last := res.Prompts[len(res.Prompts)-1]
+	if last.Role != prompt.AssistantRole || last.Text != "here is the price" {
+		t.Fatalf("final prompt = %+v, want the assistant text of the last turn", last)
+	}
+}

--- a/bellmand/bellamnd.go
+++ b/bellmand/bellamnd.go
@@ -627,6 +627,8 @@ func Gen(proxy *bellman.Proxy, apiKeyConfigs map[string]ApiKeyConfig, rateLimite
 				"token-input", response.Metadata.InputTokens,
 				"token-thinking", response.Metadata.ThinkingTokens,
 				"token-output", response.Metadata.OutputTokens,
+				"token-cached", response.Metadata.CachedTokens,
+				"token-cache-write", response.Metadata.CacheWriteTokens,
 				"token-total", response.Metadata.TotalTokens,
 			)
 
@@ -636,6 +638,8 @@ func Gen(proxy *bellman.Proxy, apiKeyConfigs map[string]ApiKeyConfig, rateLimite
 			tokensCounter.WithLabelValues(response.Metadata.Model, apiKeyId, keyName, "input").Add(float64(response.Metadata.InputTokens))
 			tokensCounter.WithLabelValues(response.Metadata.Model, apiKeyId, keyName, "thinking").Add(float64(response.Metadata.ThinkingTokens))
 			tokensCounter.WithLabelValues(response.Metadata.Model, apiKeyId, keyName, "output").Add(float64(response.Metadata.OutputTokens))
+			tokensCounter.WithLabelValues(response.Metadata.Model, apiKeyId, keyName, "cached").Add(float64(response.Metadata.CachedTokens))
+			tokensCounter.WithLabelValues(response.Metadata.Model, apiKeyId, keyName, "cache_write").Add(float64(response.Metadata.CacheWriteTokens))
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -774,6 +778,8 @@ func Gen(proxy *bellman.Proxy, apiKeyConfigs map[string]ApiKeyConfig, rateLimite
 				"token-input", tokenMetadata.InputTokens,
 				"token-thinking", tokenMetadata.ThinkingTokens,
 				"token-output", tokenMetadata.OutputTokens,
+				"token-cached", tokenMetadata.CachedTokens,
+				"token-cache-write", tokenMetadata.CacheWriteTokens,
 				"token-total", totalTokens,
 			)
 
@@ -783,6 +789,8 @@ func Gen(proxy *bellman.Proxy, apiKeyConfigs map[string]ApiKeyConfig, rateLimite
 			streamTokensCounter.WithLabelValues(modelName, apiKeyId, keyName, "input").Add(float64(tokenMetadata.InputTokens))
 			streamTokensCounter.WithLabelValues(modelName, apiKeyId, keyName, "thinking").Add(float64(tokenMetadata.ThinkingTokens))
 			streamTokensCounter.WithLabelValues(modelName, apiKeyId, keyName, "output").Add(float64(tokenMetadata.OutputTokens))
+			streamTokensCounter.WithLabelValues(modelName, apiKeyId, keyName, "cached").Add(float64(tokenMetadata.CachedTokens))
+			streamTokensCounter.WithLabelValues(modelName, apiKeyId, keyName, "cache_write").Add(float64(tokenMetadata.CacheWriteTokens))
 		})
 	}
 }

--- a/client.go
+++ b/client.go
@@ -321,6 +321,7 @@ func (g *generator) Prompt(conversation ...prompt.Prompt) (*gen.Response, error)
 		"token-input", response.Metadata.InputTokens,
 		"token-thinking", response.Metadata.ThinkingTokens,
 		"token-output", response.Metadata.OutputTokens,
+		"token-cached", response.Metadata.CachedTokens,
 		"token-total", response.Metadata.TotalTokens,
 	)
 
@@ -614,6 +615,7 @@ func (g *generator) processStreamingResponse(streamResp *gen.StreamResponse, too
 			"token-input", streamResp.Metadata.InputTokens,
 			"token-thinking", streamResp.Metadata.ThinkingTokens,
 			"token-output", streamResp.Metadata.OutputTokens,
+			"token-cached", streamResp.Metadata.CachedTokens,
 			"token-total", streamResp.Metadata.TotalTokens,
 		)
 	}

--- a/models/gen/generator.go
+++ b/models/gen/generator.go
@@ -211,6 +211,28 @@ func (b *Generator) IncludeThinkingParts(thinkingParts bool) *Generator {
 	return bb
 }
 
+// PromptCache asks the provider to cache the reusable prefix of the request -
+// system prompt, tool definitions and the conversation so far - which makes
+// multi-turn and tool-calling loops substantially cheaper, since each turn
+// resends the whole history.
+//
+// Providers differ in what this does. Anthropic requires explicit cache
+// breakpoints, so bellman places them (on the tool definitions, the system
+// prompt and the end of the conversation) only when this is enabled. OpenAI and
+// VertexAI cache eligible prefixes automatically, so enabling it changes
+// nothing for them. Either way, cache hits are reported as
+// Metadata.CachedTokens and cache writes as Metadata.CacheWriteTokens.
+//
+// Providers only cache prefixes above a model-dependent minimum length and
+// evict them after a few minutes of inactivity; below that the request behaves
+// as if caching were off.
+func (b *Generator) PromptCache(promptCache bool) *Generator {
+	bb := b.clone()
+	bb.Request.PromptCache = promptCache
+
+	return bb
+}
+
 type Option func(generator *Generator) *Generator
 
 func WithRequest(req Request) Option {
@@ -306,5 +328,11 @@ func WithThinkingBudget(thinkingBudget int) Option {
 func WithThinkingParts(thinkingParts bool) Option {
 	return func(g *Generator) *Generator {
 		return g.IncludeThinkingParts(thinkingParts)
+	}
+}
+
+func WithPromptCache(promptCache bool) Option {
+	return func(g *Generator) *Generator {
+		return g.PromptCache(promptCache)
 	}
 }

--- a/models/gen/request.go
+++ b/models/gen/request.go
@@ -24,6 +24,12 @@ type Request struct {
 	ThinkingBudget *int  `json:"thinking_budget,omitempty"`
 	ThinkingParts  *bool `json:"thinking_parts,omitempty"`
 
+	// PromptCache asks the provider to cache the reusable prefix of this
+	// request - system prompt, tool definitions and the conversation so far -
+	// so replaying a growing conversation does not pay full price for the
+	// history on every turn. See Generator.PromptCache.
+	PromptCache bool `json:"prompt_cache,omitempty"`
+
 	TopP             *float64 `json:"top_p,omitempty"`
 	TopK             *int     `json:"top_k,omitempty"`
 	Temperature      *float64 `json:"temperature,omitempty"`

--- a/models/gen/response.go
+++ b/models/gen/response.go
@@ -15,6 +15,10 @@ type StreamingResponseType string
 const TYPE_DELTA StreamingResponseType = "delta"
 const TYPE_THINKING_DELTA StreamingResponseType = "thinking_delta"
 const TYPE_BLOCK StreamingResponseType = "block" // a finalized replay-ready prompt (thinking or assistant-text with signature); Role tells which
+// TYPE_METADATA carries the token accounting of the stream so far. Each frame is
+// a complete running total, not a delta, so a consumer can simply keep the last
+// frame it saw - providers that receive usage piecemeal must accumulate rather
+// than forward the piece that changed.
 const TYPE_METADATA StreamingResponseType = "metadata"
 const TYPE_EOF StreamingResponseType = "EOF"
 const TYPE_ERROR StreamingResponseType = "ERROR"

--- a/models/models.go
+++ b/models/models.go
@@ -1,10 +1,21 @@
 package models
 
 type Metadata struct {
-	Model          string         `json:"model,omitempty"`
-	InputTokens    int            `json:"input_tokens,omitempty"`
-	ThinkingTokens int            `json:"thinking_tokens,omitempty"`
-	OutputTokens   int            `json:"output_tokens,omitempty"`
-	TotalTokens    int            `json:"total_tokens,omitempty"`
-	Other          map[string]any `json:"other,omitempty"`
+	Model          string `json:"model,omitempty"`
+	InputTokens    int    `json:"input_tokens,omitempty"`
+	ThinkingTokens int    `json:"thinking_tokens,omitempty"`
+	OutputTokens   int    `json:"output_tokens,omitempty"`
+	TotalTokens    int    `json:"total_tokens,omitempty"`
+
+	// CachedTokens is the part of the input that was served from the provider's
+	// prompt cache instead of being processed again. It is a subset of the
+	// input, not an addition to it, and is billed at a discount.
+	CachedTokens int `json:"cached_tokens,omitempty"`
+
+	// CacheWriteTokens is the part of the input that was written to the prompt
+	// cache by this request, billed at a premium. Only providers with explicit
+	// cache breakpoints report it; providers that cache implicitly leave it 0.
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+
+	Other map[string]any `json:"other,omitempty"`
 }

--- a/services/anthropic/anthropic_integration_test.go
+++ b/services/anthropic/anthropic_integration_test.go
@@ -28,5 +28,9 @@ func TestAnthropicIntegration(t *testing.T) {
 		Agent:               true,
 		StreamThinkingTools: true,
 		StreamAgentMultiHop: true,
+		// Anthropic is the only provider where bellman has to place the cache
+		// breakpoints itself. OpenAI and VertexAI cache automatically and
+		// best-effort, which is too flaky to assert on.
+		PromptCache: true,
 	})
 }

--- a/services/anthropic/llm.go
+++ b/services/anthropic/llm.go
@@ -99,6 +99,22 @@ func (g *generator) Stream(conversation ...prompt.Prompt) (<-chan *gen.StreamRes
 		}
 
 		var role string
+		// Running usage for the message. Every metadata frame carries the total
+		// so far rather than the piece that just changed, so a consumer that
+		// keeps the last frame it saw (or stops reading early) still gets a
+		// complete and consistent picture.
+		var usage anthropicUsage
+		var usageModel string
+		emitUsage := func() {
+			model := usageModel
+			if model == "" {
+				model = g.request.Model.Name
+			}
+			stream <- &gen.StreamResponse{
+				Type:     gen.TYPE_METADATA,
+				Metadata: usageToMetadata(model, usage),
+			}
+		}
 		// Per-content-block state. Anthropic emits content_block_start →
 		// content_block_delta* → content_block_stop for each block in a turn;
 		// we accumulate text/tool_use/thinking across those events and emit a
@@ -160,32 +176,18 @@ func (g *generator) Stream(conversation ...prompt.Prompt) (<-chan *gen.StreamRes
 				return
 			}
 
-			if ss.Usage != nil {
-				totalTokens := ss.Usage.InputTokens + ss.Usage.OutputTokens
-				stream <- &gen.StreamResponse{
-					Type: gen.TYPE_METADATA,
-					Metadata: &models.Metadata{
-						Model:          g.request.Model.Name,
-						InputTokens:    ss.Usage.InputTokens,
-						OutputTokens:   ss.Usage.OutputTokens,
-						ThinkingTokens: 0,
-						TotalTokens:    totalTokens,
-					},
-				}
-
+			// message_start names the model the request resolved to, which is
+			// more precise than the requested name (aliases like "-latest").
+			if ss.Message != nil && ss.Message.Model != "" {
+				usageModel = ss.Message.Model
 			}
-			if ss.Message != nil && (ss.Message.Usage.InputTokens != 0 || ss.Message.Usage.OutputTokens != 0) {
-				totalTokens := ss.Message.Usage.InputTokens + ss.Message.Usage.OutputTokens
-				stream <- &gen.StreamResponse{
-					Type: gen.TYPE_METADATA,
-					Metadata: &models.Metadata{
-						Model:          ss.Message.Model,
-						InputTokens:    ss.Message.Usage.InputTokens,
-						OutputTokens:   ss.Message.Usage.OutputTokens,
-						ThinkingTokens: 0,
-						TotalTokens:    totalTokens,
-					},
-				}
+			if ss.Usage != nil {
+				usage.mergeMax(*ss.Usage)
+				emitUsage()
+			}
+			if ss.Message != nil && (ss.Message.Usage.inputTokens() != 0 || ss.Message.Usage.OutputTokens != 0) {
+				usage.mergeMax(ss.Message.Usage)
+				emitUsage()
 			}
 
 			if ss.Message != nil {
@@ -392,11 +394,13 @@ func (g *generator) Prompt(conversation ...prompt.Prompt) (*gen.Response, error)
 
 	res := &gen.Response{
 		Metadata: models.Metadata{
-			Model:          g.request.Model.FQN(),
-			InputTokens:    respModel.Usage.InputTokens,
-			OutputTokens:   respModel.Usage.OutputTokens,
-			ThinkingTokens: 0,
-			TotalTokens:    respModel.Usage.InputTokens + respModel.Usage.OutputTokens,
+			Model:            g.request.Model.FQN(),
+			InputTokens:      respModel.Usage.inputTokens(),
+			OutputTokens:     respModel.Usage.OutputTokens,
+			ThinkingTokens:   0,
+			CachedTokens:     respModel.Usage.CacheReadInputTokens,
+			CacheWriteTokens: respModel.Usage.CacheCreationInputTokens,
+			TotalTokens:      respModel.Usage.inputTokens() + respModel.Usage.OutputTokens,
 		},
 	}
 	for _, c := range respModel.Content {
@@ -434,6 +438,45 @@ func (g *generator) Prompt(conversation ...prompt.Prompt) (*gen.Response, error)
 
 	return res, nil
 }
+func usageToMetadata(model string, usage anthropicUsage) *models.Metadata {
+	return &models.Metadata{
+		Model:            model,
+		InputTokens:      usage.inputTokens(),
+		OutputTokens:     usage.OutputTokens,
+		ThinkingTokens:   0,
+		CachedTokens:     usage.CacheReadInputTokens,
+		CacheWriteTokens: usage.CacheCreationInputTokens,
+		TotalTokens:      usage.inputTokens() + usage.OutputTokens,
+	}
+}
+
+// setCacheBreakpoints marks the reusable prefix of the request for caching.
+// Anthropic caches everything up to an explicit breakpoint, in the request order
+// tools → system → messages, so one breakpoint at the end of each of those three
+// segments (of the four allowed) covers the whole prefix. The breakpoint on the
+// conversation moves with it, which is what makes a growing conversation cheap:
+// each turn reads the prefix cached by the previous turn and extends it.
+func setCacheBreakpoints(model *request) {
+	if n := len(model.Tools); n > 0 {
+		model.Tools[n-1].CacheControl = ephemeralCache()
+	}
+	if n := len(model.System); n > 0 {
+		model.System[n-1].CacheControl = ephemeralCache()
+	}
+	if n := len(model.Messages); n > 0 {
+		// cache_control is not accepted on thinking blocks, so anchor the
+		// breakpoint on the last block of the turn that can carry one.
+		content := model.Messages[n-1].Content
+		for i := len(content) - 1; i >= 0; i-- {
+			if content[i].Type == "thinking" || content[i].Type == "redacted_thinking" {
+				continue
+			}
+			content[i].CacheControl = ephemeralCache()
+			break
+		}
+	}
+}
+
 func (g *generator) prompt(conversation ...prompt.Prompt) (*http.Request, request, error) {
 	var pdfBeta bool
 
@@ -446,9 +489,12 @@ func (g *generator) prompt(conversation ...prompt.Prompt) (*http.Request, reques
 		Temperature:   g.request.Temperature,
 		TopP:          g.request.TopP,
 		TopK:          g.request.TopK,
-		System:        g.request.SystemPrompt,
 		StopSequences: g.request.StopSequences,
 		toolBelt:      make(map[string]*tools.Tool),
+	}
+
+	if g.request.SystemPrompt != "" {
+		model.System = []reqSystemBlock{{Type: "text", Text: g.request.SystemPrompt}}
 	}
 
 	if g.request.MaxTokens != nil && *g.request.MaxTokens > 0 {
@@ -596,6 +642,10 @@ func (g *generator) prompt(conversation ...prompt.Prompt) (*http.Request, reques
 				}
 			}
 		}
+	}
+
+	if g.request.PromptCache {
+		setCacheBreakpoints(&model)
 	}
 
 	reqdata, err := json.Marshal(model)

--- a/services/anthropic/llm_test.go
+++ b/services/anthropic/llm_test.go
@@ -1,0 +1,320 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/modfin/bellman/models"
+	"github.com/modfin/bellman/models/gen"
+	"github.com/modfin/bellman/prompt"
+	"github.com/modfin/bellman/tools"
+)
+
+func testGenerator(t *testing.T, req gen.Request) *generator {
+	t.Helper()
+	req.Model = GenModel_4_5_haiku_latest
+	return &generator{anthropic: New("test-key"), request: req}
+}
+
+func conversation() []prompt.Prompt {
+	return []prompt.Prompt{
+		prompt.AsUser("what is the price of VOLV-B.ST?"),
+		prompt.AsToolCall("call-1", "get_price", []byte(`{"symbol":"VOLV-B.ST"}`)),
+		prompt.AsToolResponse("call-1", "get_price", `{"price":250}`),
+	}
+}
+
+func withTools() []tools.Tool {
+	return []tools.Tool{
+		tools.NewTool("get_price", tools.WithArgSchema(tools.EmptyArgs{})),
+		tools.NewTool("get_volume", tools.WithArgSchema(tools.EmptyArgs{})),
+	}
+}
+
+func TestPromptCacheDisabledSetsNoBreakpoints(t *testing.T) {
+	g := testGenerator(t, gen.Request{SystemPrompt: "you look up prices", Tools: withTools()})
+
+	_, model, err := g.prompt(conversation()...)
+	if err != nil {
+		t.Fatalf("prompt() error = %v", err)
+	}
+
+	for i, tool := range model.Tools {
+		if tool.CacheControl != nil {
+			t.Errorf("Tools[%d] has a cache breakpoint without PromptCache", i)
+		}
+	}
+	for i, block := range model.System {
+		if block.CacheControl != nil {
+			t.Errorf("System[%d] has a cache breakpoint without PromptCache", i)
+		}
+	}
+	for i, msg := range model.Messages {
+		for j, c := range msg.Content {
+			if c.CacheControl != nil {
+				t.Errorf("Messages[%d].Content[%d] has a cache breakpoint without PromptCache", i, j)
+			}
+		}
+	}
+}
+
+func TestPromptCacheSetsBreakpointsOnReusablePrefix(t *testing.T) {
+	g := testGenerator(t, gen.Request{SystemPrompt: "you look up prices", Tools: withTools(), PromptCache: true})
+
+	_, model, err := g.prompt(conversation()...)
+	if err != nil {
+		t.Fatalf("prompt() error = %v", err)
+	}
+
+	if n := len(model.Tools); n == 0 || model.Tools[n-1].CacheControl == nil {
+		t.Error("want a cache breakpoint on the last tool definition")
+	}
+	for i := 0; i < len(model.Tools)-1; i++ {
+		if model.Tools[i].CacheControl != nil {
+			t.Errorf("Tools[%d] should not carry a breakpoint, only the last one", i)
+		}
+	}
+	if n := len(model.System); n == 0 || model.System[n-1].CacheControl == nil {
+		t.Error("want a cache breakpoint on the system prompt")
+	}
+
+	// The breakpoint on the conversation has to sit on the very last block, so
+	// the next turn reads this turn's prefix out of the cache.
+	last := model.Messages[len(model.Messages)-1]
+	if n := len(last.Content); n == 0 || last.Content[n-1].CacheControl == nil {
+		t.Errorf("want a cache breakpoint on the last block of the conversation, got %+v", last)
+	}
+	breakpoints := 0
+	for _, msg := range model.Messages {
+		for _, c := range msg.Content {
+			if c.CacheControl != nil {
+				breakpoints++
+			}
+		}
+	}
+	if breakpoints != 1 {
+		t.Errorf("got %d breakpoints in the conversation, want exactly 1 (max 4 in total)", breakpoints)
+	}
+}
+
+// cache_control is rejected on thinking blocks, so a conversation whose final
+// block is thinking must anchor the breakpoint further back.
+func TestPromptCacheSkipsThinkingBlocks(t *testing.T) {
+	g := testGenerator(t, gen.Request{PromptCache: true})
+
+	_, model, err := g.prompt(
+		prompt.AsUser("hi"),
+		prompt.AsAssistant("hello"),
+		prompt.AsThinking("still pondering", []byte("sig-1"), ""),
+	)
+	if err != nil {
+		t.Fatalf("prompt() error = %v", err)
+	}
+
+	last := model.Messages[len(model.Messages)-1]
+	for _, c := range last.Content {
+		if c.Type == "thinking" && c.CacheControl != nil {
+			t.Fatal("cache breakpoint placed on a thinking block")
+		}
+	}
+	var marked int
+	for _, c := range last.Content {
+		if c.CacheControl != nil {
+			marked++
+			if c.Type != "text" {
+				t.Errorf("breakpoint placed on a %q block, want the text block", c.Type)
+			}
+		}
+	}
+	if marked != 1 {
+		t.Errorf("got %d marked blocks, want 1", marked)
+	}
+}
+
+// The system prompt is sent as text blocks (rather than a bare string) so it can
+// carry a cache breakpoint.
+func TestSystemPromptMarshalsAsTextBlocks(t *testing.T) {
+	g := testGenerator(t, gen.Request{SystemPrompt: "you look up prices"})
+
+	_, model, err := g.prompt(prompt.AsUser("hi"))
+	if err != nil {
+		t.Fatalf("prompt() error = %v", err)
+	}
+
+	body, err := json.Marshal(model)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var sent struct {
+		System []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"system"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(sent.System) != 1 || sent.System[0].Type != "text" || sent.System[0].Text != "you look up prices" {
+		t.Fatalf("system = %+v, want one text block with the system prompt", sent.System)
+	}
+
+	// An empty system prompt must stay off the wire entirely.
+	g = testGenerator(t, gen.Request{})
+	_, model, err = g.prompt(prompt.AsUser("hi"))
+	if err != nil {
+		t.Fatalf("prompt() error = %v", err)
+	}
+	body, err = json.Marshal(model)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if _, ok := raw["system"]; ok {
+		t.Error("empty system prompt was still sent")
+	}
+}
+
+// input_tokens excludes the cache counters, so the reported input has to add
+// them back for CachedTokens to be a subset of InputTokens.
+func TestUsageAccountsForCacheTokens(t *testing.T) {
+	usage := anthropicUsage{
+		InputTokens:              10,
+		OutputTokens:             7,
+		CacheReadInputTokens:     800,
+		CacheCreationInputTokens: 200,
+	}
+
+	m := usageToMetadata("claude", usage)
+	if m.InputTokens != 1010 {
+		t.Errorf("InputTokens = %d, want 1010", m.InputTokens)
+	}
+	if m.CachedTokens != 800 {
+		t.Errorf("CachedTokens = %d, want 800", m.CachedTokens)
+	}
+	if m.CacheWriteTokens != 200 {
+		t.Errorf("CacheWriteTokens = %d, want 200", m.CacheWriteTokens)
+	}
+	if m.TotalTokens != 1017 {
+		t.Errorf("TotalTokens = %d, want 1017", m.TotalTokens)
+	}
+}
+
+// streamTransport serves a canned SSE body for any request. Stream() posts via
+// http.DefaultClient, so the test swaps its transport for the duration; keep
+// these subtests serial (no t.Parallel).
+type streamTransport struct {
+	body string
+}
+
+func (s *streamTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}, nil
+}
+
+func withStreamBody(t *testing.T, body string) {
+	t.Helper()
+	original := http.DefaultClient.Transport
+	http.DefaultClient.Transport = &streamTransport{body: body}
+	t.Cleanup(func() { http.DefaultClient.Transport = original })
+}
+
+func sse(events ...string) string {
+	var b strings.Builder
+	for _, e := range events {
+		b.WriteString("data: " + e + "\n\n")
+	}
+	return b.String()
+}
+
+// Anthropic reports usage in pieces: the input and cache counters arrive on
+// message_start (where output_tokens is a placeholder) and the final output
+// count on message_delta. Consumers keep the last metadata frame, so every
+// frame has to carry the running total rather than just the piece that changed.
+func TestStreamMetadataAccumulatesUsage(t *testing.T) {
+	withStreamBody(t, sse(
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":25,"cache_read_input_tokens":800,"cache_creation_input_tokens":200,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+		`{"type":"message_stop"}`,
+	))
+
+	g := testGenerator(t, gen.Request{PromptCache: true})
+	stream, err := g.Stream(prompt.AsUser("hi"))
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	var last *models.Metadata
+	var frames int
+	for r := range stream {
+		if r.Type == gen.TYPE_ERROR {
+			t.Fatalf("stream error = %v", r.Content)
+		}
+		if r.Type == gen.TYPE_METADATA && r.Metadata != nil {
+			frames++
+			last = r.Metadata
+		}
+	}
+
+	if frames == 0 || last == nil {
+		t.Fatal("no metadata frames in stream")
+	}
+	if last.InputTokens != 1025 {
+		t.Errorf("InputTokens = %d, want 1025 (25 uncached + 800 read + 200 written)", last.InputTokens)
+	}
+	if last.OutputTokens != 15 {
+		t.Errorf("OutputTokens = %d, want 15 (message_start's 1 is a placeholder)", last.OutputTokens)
+	}
+	if last.CachedTokens != 800 {
+		t.Errorf("CachedTokens = %d, want 800", last.CachedTokens)
+	}
+	if last.CacheWriteTokens != 200 {
+		t.Errorf("CacheWriteTokens = %d, want 200", last.CacheWriteTokens)
+	}
+	if last.TotalTokens != 1040 {
+		t.Errorf("TotalTokens = %d, want 1040", last.TotalTokens)
+	}
+	if last.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("Model = %q, want the model the response resolved to", last.Model)
+	}
+}
+
+// Every frame, not just the last, has to be a complete running total: consumers
+// that stop reading early (or a proxy that forwards frames as they arrive) must
+// never see the input drop back to zero.
+func TestStreamMetadataFramesAreNeverPartial(t *testing.T) {
+	withStreamBody(t, sse(
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":25,"output_tokens":1}}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+		`{"type":"message_stop"}`,
+	))
+
+	g := testGenerator(t, gen.Request{})
+	stream, err := g.Stream(prompt.AsUser("hi"))
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	for r := range stream {
+		if r.Type != gen.TYPE_METADATA || r.Metadata == nil {
+			continue
+		}
+		if r.Metadata.InputTokens != 25 {
+			t.Errorf("metadata frame reports InputTokens = %d, want 25 in every frame", r.Metadata.InputTokens)
+		}
+		if r.Metadata.TotalTokens < r.Metadata.InputTokens {
+			t.Errorf("metadata frame TotalTokens = %d is below InputTokens = %d", r.Metadata.TotalTokens, r.Metadata.InputTokens)
+		}
+	}
+}

--- a/services/anthropic/request.go
+++ b/services/anthropic/request.go
@@ -17,8 +17,7 @@ type request struct {
 
 	StopSequences []string `json:"stop_sequences,omitempty"`
 
-	// System, System.type must be "text"
-	System string `json:"system,omitempty"`
+	System []reqSystemBlock `json:"system,omitempty"`
 
 	Tool  *reqToolChoice `json:"tool_choice,omitempty"`
 	Tools []reqTool      `json:"tools,omitempty"`
@@ -48,6 +47,23 @@ type reqMessages struct {
 	Content []reqContent `json:"content"`
 }
 
+type reqSystemBlock struct {
+	Type         string           `json:"type"` // must be "text"
+	Text         string           `json:"text"`
+	CacheControl *reqCacheControl `json:"cache_control,omitempty"`
+}
+
+// reqCacheControl marks a prompt-cache breakpoint: everything in the request up
+// to and including the block it sits on becomes a cacheable prefix.
+// https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+type reqCacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+func ephemeralCache() *reqCacheControl {
+	return &reqCacheControl{Type: "ephemeral"}
+}
+
 type reqToolChoice struct {
 	// "auto, any, tool"
 	Type string `json:"type"`
@@ -57,9 +73,10 @@ type reqToolChoice struct {
 }
 
 type reqTool struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description,omitempty"`
-	InputSchema *JSONSchema `json:"input_schema,omitempty"`
+	Name         string           `json:"name"`
+	Description  string           `json:"description,omitempty"`
+	InputSchema  *JSONSchema      `json:"input_schema,omitempty"`
+	CacheControl *reqCacheControl `json:"cache_control,omitempty"`
 }
 
 type reqContent struct {
@@ -74,6 +91,8 @@ type reqContent struct {
 	Thinking  string            `json:"thinking,omitempty"`  // thinking block text
 	Signature string            `json:"signature,omitempty"` // thinking block signature
 	Data      string            `json:"data,omitempty"`      // redacted_thinking opaque payload
+
+	CacheControl *reqCacheControl `json:"cache_control,omitempty"`
 }
 
 // https://docs.anthropic.com/en/api/messages-examples#vision

--- a/services/anthropic/response.go
+++ b/services/anthropic/response.go
@@ -11,20 +11,43 @@ type anthropicResponse struct {
 		ID        string `json:"id"`
 		Input     any    `json:"input"`
 	} `json:"content"`
-	ID           string `json:"id"`
-	Model        string `json:"model"`
-	Role         string `json:"role"`
-	StopReason   string `json:"stop_reason"`
-	StopSequence any    `json:"stop_sequence"`
-	Type         string `json:"type"`
-	Usage        struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
-	} `json:"usage"`
-	Error struct {
+	ID           string         `json:"id"`
+	Model        string         `json:"model"`
+	Role         string         `json:"role"`
+	StopReason   string         `json:"stop_reason"`
+	StopSequence any            `json:"stop_sequence"`
+	Type         string         `json:"type"`
+	Usage        anthropicUsage `json:"usage"`
+	Error        struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
 	} `json:"error"`
+}
+
+// anthropicUsage reports input_tokens exclusive of the cache counters, so the
+// full input of a request is input + cache_read + cache_creation.
+type anthropicUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+}
+
+// inputTokens is the total input of the request, cached parts included.
+func (u anthropicUsage) inputTokens() int {
+	return u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+}
+
+// mergeMax folds a usage frame into u. A stream reports usage in pieces - the
+// input and cache counters on message_start, where output_tokens is only a
+// placeholder, and the final output count on message_delta - and each counter
+// only grows within a message, so keeping the larger value per field yields the
+// running total for the message so far.
+func (u *anthropicUsage) mergeMax(o anthropicUsage) {
+	u.InputTokens = max(u.InputTokens, o.InputTokens)
+	u.OutputTokens = max(u.OutputTokens, o.OutputTokens)
+	u.CacheReadInputTokens = max(u.CacheReadInputTokens, o.CacheReadInputTokens)
+	u.CacheCreationInputTokens = max(u.CacheCreationInputTokens, o.CacheCreationInputTokens)
 }
 
 type anthropicStreamResponse struct {
@@ -35,10 +58,7 @@ type anthropicStreamResponse struct {
 	Delta        *anthropicStreamContentBlock `json:"delta,omitempty"`         // Only for content_block_delta and message_delta
 	ContentBlock *anthropicStreamContentBlock `json:"content_block,omitempty"` // Only for content_block_delta and message_delta
 
-	Usage *struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
-	} `json:"usage"`
+	Usage *anthropicUsage `json:"usage"`
 }
 
 type anthropicStreamContentBlock struct {

--- a/services/openai/llm.go
+++ b/services/openai/llm.go
@@ -406,6 +406,9 @@ func responseToMetadata(r *openaiResponse) *models.Metadata {
 		OutputTokens:   output,
 		ThinkingTokens: thinking,
 		TotalTokens:    r.Usage.TotalTokens,
+		// /v1/responses caches eligible prefixes automatically; input_tokens
+		// already includes the cached part, so this is reported as a subset.
+		CachedTokens: r.Usage.InputTokensDetails.CachedTokens,
 	}
 	if r.ServiceTier != nil {
 		m.Other = map[string]any{"service_tier": *r.ServiceTier}

--- a/services/vertexai/llm.go
+++ b/services/vertexai/llm.go
@@ -317,6 +317,7 @@ func (g *generator) Stream(prompts ...prompt.Prompt) (<-chan *gen.StreamResponse
 						InputTokens:    ss.UsageMetadata.PromptTokenCount,
 						OutputTokens:   outputTokens,
 						ThinkingTokens: thinkingTokens,
+						CachedTokens:   ss.UsageMetadata.CachedContentTokenCount,
 						TotalTokens:    ss.UsageMetadata.PromptTokenCount + outputTokens + thinkingTokens,
 					},
 				}
@@ -403,16 +404,28 @@ func (g *generator) Prompt(prompts ...prompt.Prompt) (*gen.Response, error) {
 	res.Metadata.InputTokens = respModel.UsageMetadata.PromptTokenCount
 	res.Metadata.OutputTokens = outputTokens
 	res.Metadata.ThinkingTokens = thinkingTokens
+	res.Metadata.CachedTokens = respModel.UsageMetadata.CachedContentTokenCount
 	res.Metadata.TotalTokens = respModel.UsageMetadata.PromptTokenCount + outputTokens + thinkingTokens
+	callIDBase := time.Now().UnixNano()
 	for _, c := range respModel.Candidates {
-		for _, p := range c.Content.Parts {
+		// Indexes into res.Turn for this candidate's first tool call and most
+		// recent text/thinking block, so a trailing closure signature can be
+		// attached to the right block. Mirrors the handling in Stream().
+		firstCall := -1
+		lastBlock := -1
+		for idx, p := range c.Content.Parts {
 			var sig []byte
 			if p.ThoughtSignature != nil && *p.ThoughtSignature != "" {
 				sig = []byte(*p.ThoughtSignature)
 			}
 			if p.Thought != nil && *p.Thought {
 				res.Thinking = append(res.Thinking, p.Text)
-				res.Turn = append(res.Turn, prompt.AsThinking(p.Text, sig, ""))
+				// Without a signature a thinking block can't be replayed, so it
+				// is reported as visible thinking but kept out of Turn.
+				if len(sig) > 0 {
+					res.Turn = append(res.Turn, prompt.AsThinking(p.Text, sig, ""))
+					lastBlock = len(res.Turn) - 1
+				}
 				continue
 			}
 			if len(p.Text) > 0 {
@@ -422,22 +435,49 @@ func (g *generator) Prompt(prompts ...prompt.Prompt) (*gen.Response, error) {
 				// part as its own assistant prompt so the signature travels with
 				// the text that was signed.
 				res.Turn = append(res.Turn, prompt.AsAssistantWithReplay(p.Text, sig))
+				lastBlock = len(res.Turn) - 1
+				continue
 			}
 
-			if len(p.Text) == 0 && len(p.FunctionCall.Name) > 0 { // Tool calls
+			if len(p.FunctionCall.Name) > 0 { // Tool calls
 				f := p.FunctionCall
 				arg, err := json.Marshal(f.Args)
 				if err != nil {
 					return nil, fmt.Errorf("could not marshal google request, %w", err)
 				}
+				// Gemini does not hand out tool call ids; synthesize one so a
+				// tool response can be paired with the call it answers even when
+				// the same tool is called twice in one turn.
+				id := fmt.Sprintf("%d-%d", callIDBase, idx)
 				res.Tools = append(res.Tools, tools.Call{
+					ID:       id,
 					Name:     f.Name,
 					Argument: arg,
 					Ref:      model.toolBelt[f.Name],
 				})
-				res.Turn = append(res.Turn, prompt.AsToolCallWithReplay("", f.Name, arg, sig))
+				res.Turn = append(res.Turn, prompt.AsToolCallWithReplay(id, f.Name, arg, sig))
+				if firstCall < 0 {
+					firstCall = len(res.Turn) - 1
+				}
+				continue
 			}
 
+			// Closure signature part: Gemini may return the turn's
+			// thoughtSignature in a part with empty text and no functionCall.
+			// Per Gemini's docs the closure signature attaches to the first tool
+			// call of the turn; otherwise, fall back to the last text/thinking
+			// block, or keep the bytes as a standalone thinking block.
+			if len(sig) == 0 {
+				continue
+			}
+			switch {
+			case firstCall >= 0:
+				res.Turn[firstCall].Replay = sig
+			case lastBlock >= 0:
+				res.Turn[lastBlock].Replay = sig
+			default:
+				res.Turn = append(res.Turn, prompt.AsThinking("", sig, ""))
+			}
 		}
 	}
 
@@ -586,17 +626,16 @@ func (g *generator) prompt(prompts ...prompt.Prompt) (*http.Response, genRequest
 			}
 			appendPart("model", part)
 		case prompt.ThinkingRole:
-			if p.Thinking == nil {
+			// A thought part the API can't validate against a signature is not
+			// replayable, so drop it rather than send it back.
+			if p.Thinking == nil || len(p.Replay) == 0 {
 				continue
 			}
-			part := genRequestContentPart{
-				Text:    p.Thinking.Text,
-				Thought: true,
-			}
-			if len(p.Replay) > 0 {
-				part.ThoughtSignature = string(p.Replay)
-			}
-			appendPart("model", part)
+			appendPart("model", genRequestContentPart{
+				Text:             p.Thinking.Text,
+				Thought:          true,
+				ThoughtSignature: string(p.Replay),
+			})
 		default: // prompt.UserRole, prompt.AssistantRole
 			role := "user"
 			if p.Role == prompt.AssistantRole {

--- a/services/vertexai/llm_test.go
+++ b/services/vertexai/llm_test.go
@@ -1,0 +1,174 @@
+package vertexai
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/modfin/bellman/models/gen"
+	"github.com/modfin/bellman/prompt"
+	"github.com/modfin/bellman/tools"
+)
+
+type stubTransport struct {
+	body    string
+	request []byte
+}
+
+func (s *stubTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Body != nil {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		s.request = b
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte(s.body))),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func stubClient(t *testing.T, response string) (*Google, *stubTransport) {
+	t.Helper()
+	st := &stubTransport{body: response}
+	return &Google{
+		config: GoogleConfig{Project: "test-project", Region: "europe-north1"},
+		client: &http.Client{Transport: st},
+	}, st
+}
+
+const usage = `"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":10,"thoughtsTokenCount":5,"totalTokenCount":115,"cachedContentTokenCount":80}`
+
+// Gemini can return the turn's thoughtSignature in a trailing part with no text
+// and no functionCall. Prompt() must attach it to the first tool call of the
+// turn, the same way Stream() does — dropping it loses the bytes the next
+// request has to echo back.
+func TestPromptAttachesClosureSignatureToToolCall(t *testing.T) {
+	client, _ := stubClient(t, `{"candidates":[{"content":{"role":"model","parts":[
+		{"text":"i should look it up","thought":true},
+		{"functionCall":{"name":"get_price","args":{"symbol":"VOLV-B.ST"}}},
+		{"text":"","thoughtSignature":"CLOSURE-SIG"}
+	]},"finishReason":"STOP"}],`+usage+`}`)
+
+	priceTool := tools.NewTool("get_price", tools.WithArgSchema(tools.EmptyArgs{}))
+	g := client.Generator(gen.WithModel(GenModel_gemini_2_5_flash_latest), gen.WithTools(priceTool))
+
+	res, err := g.Prompt(prompt.AsUser("what is the price of VOLV-B.ST?"))
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+
+	if len(res.Tools) != 1 {
+		t.Fatalf("len(Tools) = %d, want 1", len(res.Tools))
+	}
+	if res.Tools[0].ID == "" {
+		t.Error("tool call has no ID, so its tool response cannot be paired with it")
+	}
+	if res.Tools[0].Ref == nil {
+		t.Error("tool call has no Ref")
+	}
+
+	if len(res.Turn) != 1 {
+		t.Fatalf("len(Turn) = %d, want 1 (unsigned thinking dropped, tool call kept): %+v", len(res.Turn), res.Turn)
+	}
+	call := res.Turn[0]
+	if call.Role != prompt.ToolCallRole {
+		t.Fatalf("Turn[0].Role = %q, want %q", call.Role, prompt.ToolCallRole)
+	}
+	if got := string(call.Replay); got != "CLOSURE-SIG" {
+		t.Errorf("Turn[0].Replay = %q, want the closure signature", got)
+	}
+	if call.ToolCall.ToolCallID != res.Tools[0].ID {
+		t.Errorf("Turn[0] id %q != Tools[0] id %q", call.ToolCall.ToolCallID, res.Tools[0].ID)
+	}
+	if len(res.Thinking) != 1 || res.Thinking[0] != "i should look it up" {
+		t.Errorf("Thinking = %+v, want the thought text to still be reported", res.Thinking)
+	}
+}
+
+// A thinking block without a signature cannot be replayed, so it must not enter
+// Turn — Stream() already refuses to emit those.
+func TestPromptSkipsUnsignedThinkingInTurn(t *testing.T) {
+	client, _ := stubClient(t, `{"candidates":[{"content":{"role":"model","parts":[
+		{"text":"unsigned thought","thought":true},
+		{"text":"signed thought","thought":true,"thoughtSignature":"SIG-T"},
+		{"text":"the answer","thoughtSignature":"SIG-A"}
+	]},"finishReason":"STOP"}],`+usage+`}`)
+
+	g := client.Generator(gen.WithModel(GenModel_gemini_2_5_flash_latest))
+	res, err := g.Prompt(prompt.AsUser("hi"))
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+
+	if len(res.Turn) != 2 {
+		t.Fatalf("len(Turn) = %d, want 2 (signed thinking + text): %+v", len(res.Turn), res.Turn)
+	}
+	if res.Turn[0].Role != prompt.ThinkingRole || string(res.Turn[0].Replay) != "SIG-T" {
+		t.Errorf("Turn[0] = %+v, want the signed thinking block", res.Turn[0])
+	}
+	if res.Turn[1].Role != prompt.AssistantRole || string(res.Turn[1].Replay) != "SIG-A" {
+		t.Errorf("Turn[1] = %+v, want the signed assistant text", res.Turn[1])
+	}
+	if len(res.Thinking) != 2 {
+		t.Errorf("len(Thinking) = %d, want 2 — both thoughts are still visible text", len(res.Thinking))
+	}
+}
+
+func TestPromptReportsCachedTokens(t *testing.T) {
+	client, _ := stubClient(t, `{"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],`+usage+`}`)
+
+	g := client.Generator(gen.WithModel(GenModel_gemini_2_5_flash_latest))
+	res, err := g.Prompt(prompt.AsUser("hi"))
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+	if res.Metadata.CachedTokens != 80 {
+		t.Errorf("Metadata.CachedTokens = %d, want 80", res.Metadata.CachedTokens)
+	}
+	if res.Metadata.InputTokens != 100 {
+		t.Errorf("Metadata.InputTokens = %d, want 100 (cached tokens are a subset)", res.Metadata.InputTokens)
+	}
+}
+
+// Unsigned thought parts cannot be validated by the API, so the request builder
+// must not send them back regardless of where the prompt came from.
+func TestRequestDropsUnsignedThinkingPrompts(t *testing.T) {
+	client, st := stubClient(t, `{"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],`+usage+`}`)
+
+	g := client.Generator(gen.WithModel(GenModel_gemini_2_5_flash_latest))
+	_, err := g.Prompt(
+		prompt.AsUser("hi"),
+		prompt.AsThinking("unsigned", nil, ""),
+		prompt.AsThinking("signed", []byte("SIG-T"), ""),
+		prompt.AsAssistant("previous answer"),
+		prompt.AsUser("and now?"),
+	)
+	if err != nil {
+		t.Fatalf("Prompt() error = %v", err)
+	}
+
+	var sent genRequest
+	if err := json.Unmarshal(st.request, &sent); err != nil {
+		t.Fatalf("could not decode sent request: %v", err)
+	}
+
+	var thoughts []genRequestContentPart
+	for _, c := range sent.Contents {
+		for _, p := range c.Parts {
+			if p.Thought {
+				thoughts = append(thoughts, p)
+			}
+		}
+	}
+	if len(thoughts) != 1 {
+		t.Fatalf("sent %d thought parts, want 1 (the signed one): %+v", len(thoughts), thoughts)
+	}
+	if thoughts[0].ThoughtSignature != "SIG-T" {
+		t.Errorf("thought part signature = %q, want SIG-T", thoughts[0].ThoughtSignature)
+	}
+}

--- a/services/vertexai/response.go
+++ b/services/vertexai/response.go
@@ -25,12 +25,13 @@ type geminiStreamingResponse struct {
 		FinishReason string `json:"finishReason"`
 	} `json:"candidates"`
 	UsageMetadata struct {
-		PromptTokenCount     int    `json:"promptTokenCount"`
-		CandidatesTokenCount int    `json:"candidatesTokenCount"`
-		ThoughtsTokenCount   int    `json:"thoughtsTokenCount"`
-		TotalTokenCount      int    `json:"totalTokenCount"`
-		TrafficType          string `json:"trafficType"`
-		PromptTokensDetails  []struct {
+		PromptTokenCount        int    `json:"promptTokenCount"`
+		CandidatesTokenCount    int    `json:"candidatesTokenCount"`
+		ThoughtsTokenCount      int    `json:"thoughtsTokenCount"`
+		TotalTokenCount         int    `json:"totalTokenCount"`
+		CachedContentTokenCount int    `json:"cachedContentTokenCount"`
+		TrafficType             string `json:"trafficType"`
+		PromptTokensDetails     []struct {
 			Modality   string `json:"modality"`
 			TokenCount int    `json:"tokenCount"`
 		} `json:"promptTokensDetails"`
@@ -69,5 +70,7 @@ type geminiResponse struct {
 		CandidatesTokenCount int `json:"candidatesTokenCount"`
 		ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
 		TotalTokenCount      int `json:"totalTokenCount"`
+		// CachedContentTokenCount is the cached part of PromptTokenCount.
+		CachedContentTokenCount int `json:"cachedContentTokenCount"`
 	} `json:"usageMetadata"`
 }

--- a/testsuite/cache_tests.go
+++ b/testsuite/cache_tests.go
@@ -1,0 +1,46 @@
+package testsuite
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/modfin/bellman/models/gen"
+	"github.com/modfin/bellman/prompt"
+)
+
+func testPromptCache(g *gen.Generator) func(tester) {
+	return func(t tester) {
+		// Providers only cache prefixes above a model dependent minimum (1-2k
+		// tokens), so the cacheable part has to be genuinely long. It also has
+		// to be byte identical across both turns, since the prefix is the cache
+		// key.
+		var rules strings.Builder
+		for i := 0; i < 300; i++ {
+			rules.WriteString(fmt.Sprintf("Rule %d: when asked about topic %d, answer precisely and cite the rule number.\n", i, i))
+		}
+
+		cg := g.System("You answer questions about the following rule book.\n" + rules.String()).PromptCache(true)
+
+		first, err := cg.Prompt(prompt.AsUser("Reply with the single word: one"))
+		if err != nil {
+			t.Fatalf("first Prompt() error = %v", err)
+		}
+		// A previous run may have left the prefix cached, so the first turn is
+		// allowed to read it instead of writing it.
+		if first.Metadata.CacheWriteTokens == 0 && first.Metadata.CachedTokens == 0 {
+			t.Fatalf("first turn neither wrote nor read the prompt cache: %+v", first.Metadata)
+		}
+
+		second, err := cg.Prompt(prompt.AsUser("Reply with the single word: two"))
+		if err != nil {
+			t.Fatalf("second Prompt() error = %v", err)
+		}
+		if second.Metadata.CachedTokens == 0 {
+			t.Fatalf("second turn did not read the prompt cache: %+v", second.Metadata)
+		}
+		if second.Metadata.CachedTokens > second.Metadata.InputTokens {
+			t.Fatalf("CachedTokens %d exceeds InputTokens %d, cached tokens must be a subset of the input: %+v",
+				second.Metadata.CachedTokens, second.Metadata.InputTokens, second.Metadata)
+		}
+	}
+}

--- a/testsuite/stream_thinking_tests.go
+++ b/testsuite/stream_thinking_tests.go
@@ -84,13 +84,9 @@ func testStreamThinkingTools(g *gen.Generator) func(tester) {
 
 			case gen.TYPE_METADATA:
 				if r.Metadata != nil {
-					metadata.InputTokens += r.Metadata.InputTokens
-					metadata.OutputTokens += r.Metadata.OutputTokens
-					metadata.ThinkingTokens += r.Metadata.ThinkingTokens
-					metadata.TotalTokens += r.Metadata.TotalTokens
-					if r.Metadata.Model != "" {
-						metadata.Model = r.Metadata.Model
-					}
+					// Frames are running totals rather than deltas, so the last
+					// one is the complete accounting for the stream.
+					metadata = *r.Metadata
 				}
 
 			case gen.TYPE_ERROR:
@@ -118,6 +114,11 @@ func testStreamThinkingTools(g *gen.Generator) func(tester) {
 
 		if metadata.OutputTokens == 0 && metadata.TotalTokens == 0 {
 			t.Fatalf("expected non-zero output/total tokens in metadata, got %+v", metadata)
+		}
+		// The final frame must account for the whole stream, input included.
+		// Providers that receive usage piecemeal have to accumulate it.
+		if metadata.InputTokens == 0 {
+			t.Fatalf("expected the final metadata frame to report input tokens, got %+v", metadata)
 		}
 		if metadata.Model == "" {
 			t.Fatalf("expected model name in metadata")

--- a/testsuite/suite.go
+++ b/testsuite/suite.go
@@ -20,6 +20,7 @@ type Capabilities struct {
 	Agent               bool // agent.Run[T] — multi-depth tool-calling loop with structured result
 	StreamThinkingTools bool // Stream() interleaving text + thinking + tool-call deltas (single turn) — implies Thinking
 	StreamAgentMultiHop bool // Stream() driven multi-turn agent loop; signature replay assertions gated by Thinking
+	PromptCache         bool // PromptCache(true) produces cache writes and reads reported in Metadata
 }
 
 // EmbedCapabilities declares which embed-side features the model under test
@@ -84,6 +85,13 @@ func Run(t *testing.T, g *gen.Generator, caps Capabilities) {
 				t.Skip("capability StreamThinkingTools not advertised")
 			}
 			withRetry(t, retryAttempts, testStreamThinkingTools(g))
+		})
+
+		t.Run("prompt_cache", func(t *testing.T) {
+			if !caps.PromptCache {
+				t.Skip("capability PromptCache not advertised")
+			}
+			withRetry(t, retryAttempts, testPromptCache(g))
 		})
 
 		t.Run("stream/agent_multihop", func(t *testing.T) {


### PR DESCRIPTION
Five fixes to how conversations are retained and replayed, found while auditing the session/context-retention path. Each one has tests that fail before the change and pass after.

## 1. `agent.Run` dropped the final assistant turn

`Result.Prompts` never included the terminating response's `Turn`, so the returned conversation could not be used as history for a follow-up turn: the model's own answer, and the signature attached to it, were missing. The README's own example presents `res.Prompts` as if it were the full conversation.

`RunWithToolsOnly` keeps only the final turn's assistant text - its synthetic `__return_result_tool__` call never gets a tool response, and the turn's signature is validated against that dropped call, so neither is replay-safe.

## 2. Both agent loops appended into the caller's slice

`Run(..., myPrompts...)` aliases the caller's backing array, and the loop's appends wrote into its spare capacity, visible to anything else sharing that array. Both functions now copy the history on entry.

## 3. VertexAI's non-streaming path lagged its streaming path

Three divergences in `Prompt()`, all handled correctly in `Stream()`:

- **Closure signatures were dropped.** Gemini may return the turn's `thoughtSignature` in a trailing part with no text and no `functionCall`; it now attaches to the turn's first tool call, falling back to the last text/thinking block.
- **Unsigned thinking blocks were replayed.** They cannot be validated by the API, so they stay out of `Turn` (still reported in `Response.Thinking`), and the request builder drops them regardless of origin - the same guard Anthropic's builder already had.
- **Tool calls had no ids.** Synthesized ids now travel on both `Response.Tools` and the `Turn` prompt, so a tool response can be paired with the call it answers even when the same tool is called twice in one turn.

## 4. Prompt caching (new)

Every turn resends the whole history, so the same system prompt, tool definitions and prior turns were reprocessed at full price on every call, with no way to observe it - `cached_tokens` was parsed from OpenAI responses and thrown away.

New `Generator.PromptCache(bool)` / `gen.WithPromptCache` / `Request.PromptCache`:

- **Anthropic** needs explicit breakpoints, so bellman places them on the last tool definition, the system prompt, and the end of the conversation (3 of the 4 allowed). The moving conversation breakpoint is what makes a growing history cheap - each turn reads the prefix the previous turn wrote. Breakpoints skip thinking blocks, which reject `cache_control`. The system prompt is now sent as text blocks so it can carry one.
- **OpenAI / VertexAI** cache automatically; the flag is a documented no-op there.
- `Metadata.CachedTokens` and `Metadata.CacheWriteTokens` are reported by all three, aggregated across agent loops, logged, and exported as `cached` / `cache_write` on the bellmand token counters.

Anthropic reports `input_tokens` exclusive of the cache counters, so `InputTokens` now adds them back and `CachedTokens` is a subset of the input for every provider. Side effect: bellmand's rate limiter no longer undercounts cached Anthropic requests.

## 5. Anthropic streaming lost input and cache token accounting

Usage arrives in pieces - `input_tokens` and the cache counters on `message_start` (where `output_tokens` is a placeholder), the final output count on `message_delta` - and each piece was forwarded as its own metadata frame. The last frame, the one consumers keep, held only output tokens.

The provider now keeps a running total and emits the merged view on every update. The model name prefers what the response resolved to; previously the two frames disagreed with each other. The contract is written down on `TYPE_METADATA`: frames are complete running totals, not deltas.

`bellmand` is unchanged here - with cumulative frames its last-frame-wins is correct, and a defensive merge in the proxy would mask provider bugs like this rather than surface them.

## Tests

No provider keys locally, so the integration suite skips. Local coverage drives the real code paths with stubs:

- `agent/agent_test.go` - the loop through a stub prompter (3 tests)
- `services/vertexai/llm_test.go` - `Prompt()` through a stubbed transport with canned Gemini payloads, asserting both the parsed response and the replayed request (4 tests)
- `services/anthropic/llm_test.go` - breakpoint placement, system-block marshaling, usage accounting, streaming metadata (7 tests)

For what only a live API can confirm, `testsuite/cache_tests.go` adds a `PromptCache` capability (two turns over a ~6k-token system prompt, asserting a write then a read), enabled for Anthropic since it is the only provider where bellman places the breakpoints itself.

**Worth watching on the first CI run:** `stream/thinking_tools` was summing metadata frames - harmless while frames were partial, wrong under the contract above. It now keeps the last frame and asserts it reports input tokens. That is new coverage for every provider advertising `StreamThinkingTools`; if a self-hosted provider (omlx, vLLM) does not report `input_tokens` in its stream usage, this will go red. That would be a real gap, and the fix is to stop advertising the capability for that provider rather than to soften the assertion.

## Not addressed

Ollama has no retention for tool or thinking turns (`Turn` is never populated, `tool_calls` is absent from its request message type, the tool-response role goes out as `tool-resp`, and there is no integration test). Deliberately out of scope here.
